### PR TITLE
add support for meteorjs

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,0 +1,14 @@
+Package.describe({
+  name: 'pornel:slip',
+  summary: 'UI library for manipulating lists via swipe and drag gestures.',
+  version: '2.0.0',
+  git: 'https://github.com/pornel/slip.git',
+  documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0');
+  api.use('jquery', 'client');
+  
+  api.addFiles('slip.js', 'client');
+});


### PR DESCRIPTION
This will add support for MeteorJs.
After publishing this package to [atmospherejs](https://atmospherejs.com/), Meteor community can simply type `meteor add pornel:slip` to integrate `slip` in their projects.

You need first to create a meteor account with username `pornel` as packages has a name convention `username:package_name`. This is [the signup page](https://www.meteor.com/sign-up). 

Once you have your own meteor account you can follow [this guide](https://guide.meteor.com/writing-atmosphere-packages.html#publishing-atmosphere) to publish the package.

I will be more than happy to assist you.


