### PR TITLE
Add option to ignore elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ li {
 
 iOS also tends to add highlight color to tapped areas. If that bothers you, apply `-webkit-tap-highlight-color: rgba(0,0,0,0);` to tappable elements.
 
+## Configuration
+
+You can also provide an options object when initialising Slip:
+
+```js
+new Slip(element, {
+    ignoredElements: '#imnothere' // Allows you to provide any valid CSS selector, elements matching it will be ignored by Slip.
+        // Useful when you have invisible elements in your container but will cause bugs when used on visible items.
+})
+```
+
 ## Accessibility and focus management
 
 In the source code there's an `accessibility` object with settings for enabling ARIA roles on elements and focus when elements are used. Set `focus: true` in that array for potentially improved screen reader use.


### PR DESCRIPTION
As I described in #101, some frameworks might inject invisible elements to the Slip container. Having an invisible item in Slip container causes every item that is dragged down, no matter where dropped, to report as it moved to the last position.
[Here's a demo](https://jsbin.com/hapugug/edit?html,console,output)

I added a configuration value that if set would ignore specified selectors from node search so you could skip detecting invisible elements in Slip container. It swaps back to old behavior when the option is not defined.
[Here's how the demo looks like with my fix](https://jsbin.com/xeteqek/edit?html,console,output)

The only problem is when the ignored element is visible, it may cause some weird behavior. To prevent this I tried describing the option in readme file.

Closes #101 