### PR TITLE
TypeScript rewrite

### DIFF
--- a/slip.d.ts
+++ b/slip.d.ts
@@ -2,7 +2,8 @@ export interface ISlip extends IState, IDispatch, IMovement {
     (container: HTMLElement | null, options: IOptions): ISlip;
 
     options: IOptions;
-    states: {reorder: string, swipe: string, idle: string, undecided: string};
+    states: IStates;
+    _states: () => IStates;
     attach: (container: HTMLElement) => void;
     container: HTMLElement;
     latestPosition?: IPosition;
@@ -24,9 +25,10 @@ export interface ISlip extends IState, IDispatch, IMovement {
     addMouseHandlers: () => void;
     canPreventScrolling: boolean;
     startAtPosition: (position: IPosition) => void;
-    setTarget: (e: MSInputMethodContext) => boolean;
+    setTarget: (e: MouseEvent & MSGesture) => boolean;
     getSiblings: (target: ITarget) => ISibling[];
     updatePosition: (e: MouseEvent | TouchEvent, position: IPosition) => void;
+    cancel: () => void;
 }
 
 interface IDispatch {
@@ -52,7 +54,7 @@ export interface IPosition {
     time: number;
 }
 
-export interface IState {
+export interface IState extends IStateImplement {
     cancel: () => void;
     onTouchStart: (e: TouchEvent) => void;
     onTouchMove: (e: TouchEvent) => void;
@@ -63,12 +65,10 @@ export interface IState {
     onMouseLeave: (e: MouseEvent) => void;
     onSelection: (e: Event & Node) => void;
     onContainerFocus: (e: TouchEvent) => void;
-    onLeave: () => void;
-    onEnd: () => void;
-    onMove: () => void;
+
     setState: (state: ISlip['states']['idle']) => void;
-    ctor: {new(): any};
-    leaveState: () => void;
+    ctor: () => void;
+
     allowTextSelection: boolean;
 }
 
@@ -97,7 +97,7 @@ export interface IStateReorder extends IStateUndecided, ISlip {
 export interface ITarget {
     node: HTMLElement & {style: {willChange?: string;}};
     height?: number;
-    originalTarget: ITarget;
+    originalTarget: EventTarget;
     baseTransform: ITransform;
     scrollContainer: HTMLElement;
     origScrollTop: number;
@@ -116,14 +116,28 @@ export interface ITransform {
 
 export interface IMove {
     directionX?: string;
-    directionY?: string,
+    directionY?: string;
     x?: number;
     y?: number;
     originalIndex?: number;
-    direction?: number;
+    direction?: string;
     time?: number;
     spliceIndex?: number;
     insertBefore?: {node: Node & ChildNode, baseTransform: ITransform, pos: number};
+}
+
+export interface IStates {
+    idle: () => void;
+    undecided: () => void;
+    swipe: () => void;
+    reorder: () => void;
+}
+
+export interface IStateImplement {
+    leaveState: () => void;
+    onLeave: () => void;
+    onEnd: () => void;
+    onMove: () => void;
 }
 
 type TEvent = 'beforewait' | 'beforereorder' | 'beforeswipe' | 'tap' | 'afterswipe'

--- a/slip.d.ts
+++ b/slip.d.ts
@@ -1,0 +1,58 @@
+export interface ISlip extends IState {
+    (container: HTMLElement | null, options: IOptions): ISlip;
+
+    options: IOptions;
+    states: {idle: string};
+    attach: (container: HTMLElement) => void;
+    container: HTMLElement;
+}
+
+export interface IOptions {
+    keepSwipingPercent: number;
+    minimumSwipeVelocity: number;
+    minimumSwipeTime: number;
+    ignoredElements: HTMLElement[];
+    attach: ISlip['attach'];
+}
+
+export interface IState {
+    cancel: () => void;
+    onTouchStart: () => void;
+    onTouchMove: () => void;
+    onTouchEnd: () => void;
+    onMouseDown: () => void;
+    onMouseMove: () => void;
+    onMouseUp: () => void;
+    onMouseLeave: () => void;
+    onSelection: () => void;
+    onContainerFocus: () => void;
+    setState: (state: ISlip['states']['idle']) => void;
+}
+
+interface IStateSelected {
+    removeMouseHandlers: () => void;
+    usingTouch: boolean;
+    target: ITarget | null;
+    setState: (state: IStateSelected['states']['reorder']) => void;
+    states: {reorder: string, swipe: string, idle: string};
+    getAbsoluteMovement: () => {x: number, y: number, directionX: number, directionY: number};
+    canPreventScrolling: boolean;
+}
+
+export interface IStateIdle extends IStateSelected {
+
+}
+
+export interface IStateUndecided extends IStateSelected {
+    target: ITarget;
+    dispatch: (target: ITarget, event: TEvent,
+               move?: {directionX: number, directionY: number}) => void;
+}
+
+export interface ITarget {
+    node: HTMLElement & {style: {willChange?: string;}};
+    height: number;
+    originalTarget: ITarget;
+}
+
+type TEvent = 'beforewait' | 'beforereorder' | 'beforeswipe' | 'tap';

--- a/slip.d.ts
+++ b/slip.d.ts
@@ -17,7 +17,7 @@ export interface ISlip extends IState, IDispatch, IMovement {
     detach: () => void;
     setChildNodesAriaRoles: () => void;
     unSetChildNodesAriaRoles: () => void;
-    otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: | EventTarget number}[];
+    otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: | EventTarget}[];
     findTargetNode: (targetNode: Node | null) => Node | null;
     mouseHandlersAttached: boolean;
     usingTouch: boolean;
@@ -77,7 +77,7 @@ interface IStateSelected extends IMovement {
     usingTouch: boolean;
     target: ITarget | null;
     setState: (state: IStateSelected['states']['reorder']) => void;
-    states: {reorder: string, swipe: string, idle: string};
+    states: ISlip['states'];
     canPreventScrolling: boolean;
     container: HTMLElement;
 }

--- a/slip.d.ts
+++ b/slip.d.ts
@@ -2,18 +2,31 @@ export interface ISlip extends IState, IDispatch, IMovement {
     (container: HTMLElement | null, options: IOptions): ISlip;
 
     options: IOptions;
-    states: {reorder: string, swipe: string, idle: string};
+    states: {reorder: string, swipe: string, idle: string, undecided: string};
     attach: (container: HTMLElement) => void;
     container: HTMLElement;
     latestPosition: IPosition;
     startPosition: IPosition;
     previousPosition: IPosition;
-    animateSwipe: (target: ITarget) => void | boolean;
+    animateSwipe: (callback: (target: ITarget) => void) => void | boolean;
     animateToZero: (callback?: (target: ITarget) => void, target?: ITarget) => void | boolean;
     getTotalMovement: () => IPosition;
     updateScrolling: () => void;
     target: ITarget;
     state: IState;
+    detach: () => void;
+    setChildNodesAriaRoles: () => void;
+    unSetChildNodesAriaRoles: () => void;
+    otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: | EventTarget number}[];
+    findTargetNode: (targetNode: Node | null) => Node | null;
+    mouseHandlersAttached: boolean;
+    usingTouch: boolean;
+    addMouseHandlers: () => void;
+    canPreventScrolling: boolean;
+    startAtPosition: (position: IPosition) => void;
+    setTarget: (e: Event & {target: Node | EventTarget | null}) => boolean;
+    getSiblings: (target: ITarget) => ISibling[];
+    updatePosition: (e: MouseEvent | TouchEvent, position: IPosition) => void;
 }
 
 interface IDispatch {
@@ -33,7 +46,7 @@ export interface IOptions {
     attach: ISlip['attach'];
 }
 
-interface IPosition {
+export interface IPosition {
     x: number;
     y: number;
     time: number;
@@ -52,7 +65,11 @@ export interface IState {
     onContainerFocus: () => void;
     onLeave: () => void;
     onEnd: () => void;
+    onMove: () => void;
     setState: (state: ISlip['states']['idle']) => void;
+    ctor: {new(): any};
+    leaveState: () => void;
+    allowTextSelection: boolean;
 }
 
 interface IStateSelected extends IMovement {
@@ -79,9 +96,12 @@ export interface IStateReorder extends IStateUndecided, ISlip {
 
 export interface ITarget {
     node: HTMLElement & {style: {willChange?: string;}};
-    height: number;
+    height?: number;
     originalTarget: ITarget;
     baseTransform: ITransform;
+    scrollContainer: HTMLElement;
+    origScrollTop: number;
+    origScrollHeight: number;
 }
 
 export interface ISibling {
@@ -107,4 +127,5 @@ interface IMove {
 }
 
 type TEvent = 'beforewait' | 'beforereorder' | 'beforeswipe' | 'tap' | 'afterswipe'
-    | 'animateswipe' | 'cancelswipe' | 'swipe' | 'reorder';
+    | 'animateswipe' | 'cancelswipe' | 'swipe' | 'reorder'
+    | 'mouseleave' | 'mousemove' | 'mouseup' | 'blur';

--- a/slip.d.ts
+++ b/slip.d.ts
@@ -1,6 +1,4 @@
-export interface ISlip extends IState, IDispatch, IMovement {
-    (container: HTMLElement | null, options: IOptions): ISlip;
-
+export interface ISlip extends IDispatch, IMovement {
     options: IOptions;
     states: IStates;
     _states: () => IStates;
@@ -14,21 +12,21 @@ export interface ISlip extends IState, IDispatch, IMovement {
     getTotalMovement: () => IPosition;
     updateScrolling: () => void;
     target?: ITarget;
-    state?: IState;
+    state: IStateImplement;
     detach: () => void;
     setChildNodesAriaRoles: () => void;
     unSetChildNodesAriaRoles: () => void;
-    otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: | EventTarget}[];
     findTargetNode: (targetNode: Node | null) => Node | null;
     mouseHandlersAttached: boolean;
     usingTouch: boolean;
     addMouseHandlers: () => void;
     canPreventScrolling: boolean;
     startAtPosition: (position: IPosition) => void;
-    setTarget: (e: MouseEvent & MSGesture) => boolean;
+    setTarget: (e: Event) => boolean;
     getSiblings: (target: ITarget) => ISibling[];
     updatePosition: (e: MouseEvent | TouchEvent, position: IPosition) => void;
     cancel: () => void;
+    otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: EventTarget}[];
 }
 
 interface IDispatch {
@@ -59,18 +57,19 @@ export interface IState extends IStateImplement {
     onTouchStart: (e: TouchEvent) => void;
     onTouchMove: (e: TouchEvent) => void;
     onTouchEnd: (e: TouchEvent) => void;
-    onMouseDown: (e: MouseEvent & MSGesture) => void;
+    onMouseDown: (e: MouseEvent) => void;
     onMouseMove: (e: MouseEvent) => void;
     onMouseUp: (e: MouseEvent) => void;
     onMouseLeave: (e: MouseEvent) => void;
-    onSelection: (e: Event & Node) => void;
-    onContainerFocus: (e: TouchEvent) => void;
+    onSelection: (e: UIEvent & Node) => void;
+    onContainerFocus: (e: UIEvent) => void;
 
     setState: (state: ISlip['states']['idle']) => void;
-    ctor: () => void;
 
     allowTextSelection: boolean;
 }
+
+export type TMouseEvent = MouseEvent & MSGesture & EventListenerOrEventListenerObject;
 
 interface IStateSelected extends IMovement {
     removeMouseHandlers: () => void;
@@ -80,18 +79,6 @@ interface IStateSelected extends IMovement {
     states: ISlip['states'];
     canPreventScrolling: boolean;
     container: HTMLElement;
-}
-
-export interface IStateIdle extends IStateSelected {
-
-}
-
-export interface IStateUndecided extends IStateSelected, IDispatch {
-    target: ITarget;
-}
-
-export interface IStateReorder extends IStateUndecided, ISlip {
-
 }
 
 export interface ITarget {
@@ -128,9 +115,9 @@ export interface IMove {
 
 export interface IStates {
     idle: () => void;
-    undecided: () => void;
-    swipe: () => void;
-    reorder: () => void;
+    undecided: () => IStateImplement;
+    swipe: () => IStateImplement;
+    reorder: () => IStateImplement;
 }
 
 export interface IStateImplement {
@@ -138,6 +125,7 @@ export interface IStateImplement {
     onLeave: () => void;
     onEnd: () => void;
     onMove: () => void;
+    allowTextSelection: boolean;
 }
 
 type TEvent = 'beforewait' | 'beforereorder' | 'beforeswipe' | 'tap' | 'afterswipe'

--- a/slip.d.ts
+++ b/slip.d.ts
@@ -5,15 +5,15 @@ export interface ISlip extends IState, IDispatch, IMovement {
     states: {reorder: string, swipe: string, idle: string, undecided: string};
     attach: (container: HTMLElement) => void;
     container: HTMLElement;
-    latestPosition: IPosition;
-    startPosition: IPosition;
-    previousPosition: IPosition;
+    latestPosition?: IPosition;
+    startPosition?: IPosition;
+    previousPosition?: IPosition;
     animateSwipe: (callback: (target: ITarget) => void) => void | boolean;
     animateToZero: (callback?: (target: ITarget) => void, target?: ITarget) => void | boolean;
     getTotalMovement: () => IPosition;
     updateScrolling: () => void;
-    target: ITarget;
-    state: IState;
+    target?: ITarget;
+    state?: IState;
     detach: () => void;
     setChildNodesAriaRoles: () => void;
     unSetChildNodesAriaRoles: () => void;
@@ -24,18 +24,18 @@ export interface ISlip extends IState, IDispatch, IMovement {
     addMouseHandlers: () => void;
     canPreventScrolling: boolean;
     startAtPosition: (position: IPosition) => void;
-    setTarget: (e: Event & {target: Node | EventTarget | null}) => boolean;
+    setTarget: (e: MSInputMethodContext) => boolean;
     getSiblings: (target: ITarget) => ISibling[];
     updatePosition: (e: MouseEvent | TouchEvent, position: IPosition) => void;
 }
 
 interface IDispatch {
-    dispatch: (target: ITarget['node'] | ITarget, event: TEvent,
+    dispatch: (targetNode: EventTarget, eventName: TEvent,
                move?: IMove) => void;
 }
 
 interface IMovement {
-    getAbsoluteMovement: () => Required<IMove>;
+    getAbsoluteMovement: () => IMove;
 }
 
 export interface IOptions {
@@ -54,15 +54,15 @@ export interface IPosition {
 
 export interface IState {
     cancel: () => void;
-    onTouchStart: () => void;
-    onTouchMove: () => void;
-    onTouchEnd: () => void;
-    onMouseDown: () => void;
-    onMouseMove: () => void;
-    onMouseUp: () => void;
-    onMouseLeave: () => void;
-    onSelection: () => void;
-    onContainerFocus: () => void;
+    onTouchStart: (e: TouchEvent) => void;
+    onTouchMove: (e: TouchEvent) => void;
+    onTouchEnd: (e: TouchEvent) => void;
+    onMouseDown: (e: MouseEvent & MSGesture) => void;
+    onMouseMove: (e: MouseEvent) => void;
+    onMouseUp: (e: MouseEvent) => void;
+    onMouseLeave: (e: MouseEvent) => void;
+    onSelection: (e: Event & Node) => void;
+    onContainerFocus: (e: TouchEvent) => void;
     onLeave: () => void;
     onEnd: () => void;
     onMove: () => void;
@@ -114,9 +114,9 @@ export interface ITransform {
     original: string;
 }
 
-interface IMove {
-    directionX?: number;
-    directionY?: number,
+export interface IMove {
+    directionX?: string;
+    directionY?: string,
     x?: number;
     y?: number;
     originalIndex?: number;

--- a/slip.js
+++ b/slip.js
@@ -230,13 +230,14 @@ exports.Slip = function () {
                 this.target.height = this.target.node.offsetHeight;
                 this.target.node.style.willChange = transformCSSPropertyName;
                 this.target.node.style[transitionJSPropertyName] = '';
+                var holdTimer = 0;
                 if (!this.dispatch(this.target.originalTarget, 'beforewait')) {
                     if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
                         this.setState(this.states.reorder);
                     }
                 }
                 else {
-                    var holdTimer = setTimeout(function () {
+                    holdTimer = setTimeout(function () {
                         var move = _this.getAbsoluteMovement();
                         if (_this.canPreventScrolling && move.x < 15 && move.y < 25) {
                             if (_this.dispatch(_this.target.originalTarget, 'beforereorder')) {
@@ -777,7 +778,7 @@ exports.Slip = function () {
             else {
                 event = document.createEvent('Event');
                 event.initEvent('slip:' + eventName, true, true);
-                event.detail = detail;
+                // event.detail = detail;
             }
             return targetNode.dispatchEvent(event);
         },

--- a/slip.js
+++ b/slip.js
@@ -112,6 +112,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 exports.Slip = function () {
+    var _this = this;
     var accessibility = {
         // Set values to false if you don't want Slip to manage them
         container: {
@@ -277,57 +278,55 @@ exports.Slip = function () {
             },
             swipe: function () {
                 var swipeSuccess = false;
-                var container = this.container;
-                var originalIndex = findIndex(this.target, this.container.childNodes);
+                var container = _this.container;
+                var originalIndex = findIndex(_this.target, _this.container.childNodes);
                 container.classList.add('slip-swiping-container');
                 var removeClass = function () { return container.classList.remove('slip-swiping-container'); };
-                this.target.height = this.target.node.offsetHeight;
+                _this.target.height = _this.target.node.offsetHeight;
                 return {
                     leaveState: function () {
                         if (swipeSuccess) {
-                            this.animateSwipe(function (target) {
+                            _this.animateSwipe(function (target) {
                                 target.node.style[transformJSPropertyName] = target.baseTransform.original;
                                 target.node.style[transitionJSPropertyName] = '';
-                                if (this.dispatch(target.node, 'afterswipe')) {
+                                if (_this.dispatch(target.node, 'afterswipe')) {
                                     removeClass();
                                     return true;
                                 }
                                 else {
-                                    this.animateToZero(undefined, target);
+                                    _this.animateToZero(undefined, target);
                                 }
-                            }.bind(this));
+                            });
                         }
                         else {
-                            this.animateToZero(removeClass);
+                            _this.animateToZero(removeClass);
                         }
                     },
                     onMove: function () {
-                        var move = this.getTotalMovement();
-                        if (Math.abs(move.y) < this.target.height + 20) {
-                            if (this.dispatch(this.target.node, 'animateswipe', {
+                        var move = _this.getTotalMovement();
+                        if (Math.abs(move.y) < _this.target.height + 20) {
+                            if (_this.dispatch(_this.target.node, 'animateswipe', {
                                 x: move.x,
                                 originalIndex: originalIndex
                             })) {
-                                this.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + this.target.baseTransform.value;
+                                _this.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + _this.target.baseTransform.value;
                             }
                             return false;
                         }
                         else {
-                            this.dispatch(this.target.node, 'cancelswipe');
-                            this.setState(this.states.idle);
+                            _this.dispatch(_this.target.node, 'cancelswipe');
+                            _this.setState(_this.states.idle);
                         }
                     },
-                    onLeave: function () {
-                        this.state.onEnd.call(this);
-                    },
+                    onLeave: _this.state.onEnd,
                     onEnd: function () {
-                        var move = this.getAbsoluteMovement();
+                        var move = _this.getAbsoluteMovement();
                         var velocity = move.x / move.time;
                         // How far out has the item been swiped?
-                        var swipedPercent = Math.abs((this.startPosition.x - this.previousPosition.x) / this.container.clientWidth) * 100;
-                        var swiped = (velocity > this.options.minimumSwipeVelocity && move.time > this.options.minimumSwipeTime) || (this.options.keepSwipingPercent && swipedPercent > this.options.keepSwipingPercent);
+                        var swipedPercent = Math.abs((_this.startPosition.x - _this.previousPosition.x) / _this.container.clientWidth) * 100;
+                        var swiped = (velocity > _this.options.minimumSwipeVelocity && move.time > _this.options.minimumSwipeTime) || (_this.options.keepSwipingPercent && swipedPercent > _this.options.keepSwipingPercent);
                         if (swiped) {
-                            if (this.dispatch(this.target.node, 'swipe', {
+                            if (_this.dispatch(_this.target.node, 'swipe', {
                                 direction: move.directionX,
                                 originalIndex: originalIndex
                             })) {
@@ -335,30 +334,31 @@ exports.Slip = function () {
                             }
                         }
                         else {
-                            this.dispatch(this.target.node, 'cancelswipe');
+                            _this.dispatch(_this.target.node, 'cancelswipe');
                         }
-                        this.setState(this.states.idle);
+                        _this.setState(_this.states.idle);
                         return !swiped;
                     },
                 };
             },
-            reorder: function reorderStateInit() {
-                if (this.target.node.focus && accessibility.items.focus) {
-                    this.target.node.focus();
+            reorder: function () {
+                if (_this.target.node.focus && accessibility.items.focus) {
+                    _this.target.node.focus();
                 }
-                this.target.height = this.target.node.offsetHeight;
+                _this.target.height = _this.target.node.offsetHeight;
                 var nodes;
-                if (this.options.ignoredElements.length) {
-                    var container = this.container;
+                if (_this.options.ignoredElements.length) {
+                    var container = _this.container;
                     var query_1 = container.tagName.toLowerCase();
                     if (container.getAttribute('id')) {
                         query_1 = '#' + container.getAttribute('id');
                     }
                     else if (container.classList.length) {
-                        query_1 += '.' + container.getAttribute('class').replace(' ', '.');
+                        query_1 += '.' + container.getAttribute('class')
+                            .replace(' ', '.');
                     }
                     query_1 += ' > ';
-                    this.options.ignoredElements.forEach(function (selector) {
+                    _this.options.ignoredElements.forEach(function (selector) {
                         query_1 += ':not(' + selector + ')';
                     });
                     try {
@@ -372,14 +372,14 @@ exports.Slip = function () {
                     }
                 }
                 else {
-                    nodes = this.container.childNodes;
+                    nodes = _this.container.childNodes;
                 }
-                var originalIndex = findIndex(this.target, nodes);
+                var originalIndex = findIndex(_this.target, nodes);
                 var mouseOutsideTimer;
-                var zero = this.target.node.offsetTop + this.target.height / 2;
+                var zero = _this.target.node.offsetTop + _this.target.height / 2;
                 var otherNodes = [];
                 for (var i = 0; i < nodes.length; i++) {
-                    if (nodes[i].nodeType != 1 || nodes[i] === this.target.node)
+                    if (nodes[i].nodeType != 1 || nodes[i] === _this.target.node)
                         continue;
                     var t = nodes[i].offsetTop;
                     nodes[i].style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.2s ease-in-out';
@@ -389,24 +389,24 @@ exports.Slip = function () {
                         pos: t + (t < zero ? nodes[i].offsetHeight : 0) - zero,
                     });
                 }
-                this.target.node.classList.add('slip-reordering');
-                this.target.node.style.zIndex = '99999';
-                this.target.node.style[userSelectJSPropertyName] = 'none';
+                _this.target.node.classList.add('slip-reordering');
+                _this.target.node.style.zIndex = '99999';
+                _this.target.node.style[userSelectJSPropertyName] = 'none';
                 if (compositorDoesNotOrderLayers) {
                     // Chrome's compositor doesn't sort 2D layers
-                    this.container.style.webkitTransformStyle = 'preserve-3d';
+                    _this.container.style.webkitTransformStyle = 'preserve-3d';
                 }
-                function onMove() {
+                var onMove = function () {
                     /*jshint validthis:true */
-                    this.updateScrolling();
+                    _this.updateScrolling();
                     if (mouseOutsideTimer) {
                         // don't care where the mouse is as long as it moves
                         clearTimeout(mouseOutsideTimer);
                         mouseOutsideTimer = null;
                     }
-                    var move = this.getTotalMovement();
-                    this.target.node.style[transformJSPropertyName] = 'translate(0,' + move.y + 'px) ' + hwTopLayerMagicStyle + this.target.baseTransform.value;
-                    var height = this.target.height;
+                    var move = _this.getTotalMovement();
+                    _this.target.node.style[transformJSPropertyName] = 'translate(0,' + move.y + 'px) ' + hwTopLayerMagicStyle + _this.target.baseTransform.value;
+                    var height = _this.target.height;
                     otherNodes.forEach(function (o) {
                         var off = 0;
                         if (o.pos < 0 && move.y < 0 && o.pos > move.y) {
@@ -419,23 +419,21 @@ exports.Slip = function () {
                         o.node.style[transformJSPropertyName] = off ? 'translate(0,' + off + 'px) ' + hwLayerMagicStyle + o.baseTransform.value : o.baseTransform.original;
                     });
                     return false;
-                }
-                onMove.call(this);
+                };
+                onMove();
                 return {
                     leaveState: function () {
                         if (mouseOutsideTimer)
                             clearTimeout(mouseOutsideTimer);
                         if (compositorDoesNotOrderLayers) {
-                            this.container.style.webkitTransformStyle = '';
+                            _this.container.style.webkitTransformStyle = '';
                         }
-                        if (this.container.focus && accessibility.container.focus) {
-                            this.container.focus();
+                        if (_this.container.focus && accessibility.container.focus) {
+                            _this.container.focus();
                         }
-                        this.target.node.classList.remove('slip-reordering');
-                        this.target.node.style[userSelectJSPropertyName] = '';
-                        this.animateToZero(function (target) {
-                            target.node.style.zIndex = '';
-                        });
+                        _this.target.node.classList.remove('slip-reordering');
+                        _this.target.node.style[userSelectJSPropertyName] = '';
+                        _this.animateToZero(function (target) { return target.node.style.zIndex = ''; });
                         otherNodes.forEach(function (o) {
                             o.node.style[transformJSPropertyName] = o.baseTransform.original;
                             o.node.style[transitionJSPropertyName] = ''; // FIXME: animate to new position
@@ -449,11 +447,11 @@ exports.Slip = function () {
                             clearTimeout(mouseOutsideTimer);
                         mouseOutsideTimer = setTimeout(function () {
                             mouseOutsideTimer = null;
-                            this.cancel();
-                        }.bind(this), 700);
+                            _this.cancel();
+                        }, 700);
                     },
                     onEnd: function () {
-                        var move = this.getTotalMovement();
+                        var move = _this.getTotalMovement();
                         var i, spliceIndex;
                         if (move.y < 0) {
                             for (i = 0; i < otherNodes.length; i++) {
@@ -471,12 +469,12 @@ exports.Slip = function () {
                             }
                             spliceIndex = i + 1;
                         }
-                        this.dispatch(this.target.node, 'reorder', {
+                        _this.dispatch(_this.target.node, 'reorder', {
                             spliceIndex: spliceIndex,
                             originalIndex: originalIndex,
                             insertBefore: otherNodes[spliceIndex] ? otherNodes[spliceIndex].node : null,
                         });
-                        this.setState(this.states.idle);
+                        _this.setState(_this.states.idle);
                         return false;
                     },
                 };
@@ -484,50 +482,50 @@ exports.Slip = function () {
         },
         attach: function (container) {
             globalInstances++;
-            if (this.container)
-                this.detach();
+            if (_this.container)
+                _this.detach();
             // In some cases taps on list elements send *only* click events and no touch events. Spotted only in Chrome 32+
             // Having event listener on body seems to solve the issue (although AFAIK may disable smooth scrolling as a side-effect)
             if (!attachedBodyHandlerHack && needsBodyHandlerHack) {
                 attachedBodyHandlerHack = true;
                 document.body.addEventListener('touchstart', nullHandler, false);
             }
-            this.container = container;
+            _this.container = container;
             // Accessibility
             if (false !== accessibility.container.tabIndex) {
-                this.container.tabIndex = accessibility.container.tabIndex;
+                _this.container.tabIndex = accessibility.container.tabIndex;
             }
             if (accessibility.container.ariaRole) {
-                this.container.setAttribute('aria-role', accessibility.container.ariaRole);
+                _this.container.setAttribute('aria-role', accessibility.container.ariaRole);
             }
-            this.setChildNodesAriaRoles();
-            this.container.addEventListener('focus', this.onContainerFocus, false);
-            this.otherNodes = [];
+            _this.setChildNodesAriaRoles();
+            _this.container.addEventListener('focus', _this.onContainerFocus, false);
+            _this.otherNodes = [];
             // selection on iOS interferes with reordering
-            document.addEventListener('selectionchange', this.onSelection, false);
+            document.addEventListener('selectionchange', _this.onSelection, false);
             // cancel is called e.g. when iOS detects multitasking gesture
-            this.container.addEventListener('touchcancel', this.cancel, false);
-            this.container.addEventListener('touchstart', this.onTouchStart, false);
-            this.container.addEventListener('touchmove', this.onTouchMove, false);
-            this.container.addEventListener('touchend', this.onTouchEnd, false);
-            this.container.addEventListener('mousedown', this.onMouseDown, false);
+            _this.container.addEventListener('touchcancel', _this.cancel, false);
+            _this.container.addEventListener('touchstart', _this.onTouchStart, false);
+            _this.container.addEventListener('touchmove', _this.onTouchMove, false);
+            _this.container.addEventListener('touchend', _this.onTouchEnd, false);
+            _this.container.addEventListener('mousedown', _this.onMouseDown, false);
             // mousemove and mouseup are attached dynamically
         },
         detach: function () {
-            this.cancel();
-            this.container.removeEventListener('mousedown', this.onMouseDown, false);
-            this.container.removeEventListener('touchend', this.onTouchEnd, false);
-            this.container.removeEventListener('touchmove', this.onTouchMove, false);
-            this.container.removeEventListener('touchstart', this.onTouchStart, false);
-            this.container.removeEventListener('touchcancel', this.cancel, false);
-            document.removeEventListener('selectionchange', this.onSelection, false);
+            _this.cancel();
+            _this.container.removeEventListener('mousedown', _this.onMouseDown, false);
+            _this.container.removeEventListener('touchend', _this.onTouchEnd, false);
+            _this.container.removeEventListener('touchmove', _this.onTouchMove, false);
+            _this.container.removeEventListener('touchstart', _this.onTouchStart, false);
+            _this.container.removeEventListener('touchcancel', _this.cancel, false);
+            document.removeEventListener('selectionchange', _this.onSelection, false);
             if (false !== accessibility.container.tabIndex) {
-                this.container.removeAttribute('tabIndex');
+                _this.container.removeAttribute('tabIndex');
             }
             if (accessibility.container.ariaRole) {
-                this.container.removeAttribute('aria-role');
+                _this.container.removeAttribute('aria-role');
             }
-            this.unSetChildNodesAriaRoles();
+            _this.unSetChildNodesAriaRoles();
             globalInstances--;
             if (!globalInstances && attachedBodyHandlerHack) {
                 attachedBodyHandlerHack = false;
@@ -560,7 +558,7 @@ exports.Slip = function () {
             this.setChildNodesAriaRoles();
         },
         setChildNodesAriaRoles: function () {
-            var nodes = this.container.childNodes;
+            var nodes = _this.container.childNodes;
             for (var i = 0; i < nodes.length; i++) {
                 if (nodes[i].nodeType != 1)
                     continue;
@@ -573,7 +571,7 @@ exports.Slip = function () {
             }
         },
         unSetChildNodesAriaRoles: function () {
-            var nodes = this.container.childNodes;
+            var nodes = _this.container.childNodes;
             for (var i = 0; i < nodes.length; i++) {
                 if (nodes[i].nodeType != 1)
                     continue;
@@ -604,21 +602,21 @@ exports.Slip = function () {
         addMouseHandlers: function () {
             // unlike touch events, mousemove/up is not conveniently fired on the same element,
             // but I don't need to listen to unrelated events all the time
-            if (!this.mouseHandlersAttached) {
-                this.mouseHandlersAttached = true;
-                document.documentElement.addEventListener('mouseleave', this.onMouseLeave, false);
-                window.addEventListener('mousemove', this.onMouseMove, true);
-                window.addEventListener('mouseup', this.onMouseUp, true);
-                window.addEventListener('blur', this.cancel, false);
+            if (!_this.mouseHandlersAttached) {
+                _this.mouseHandlersAttached = true;
+                document.documentElement.addEventListener('mouseleave', _this.onMouseLeave, false);
+                window.addEventListener('mousemove', _this.onMouseMove, true);
+                window.addEventListener('mouseup', _this.onMouseUp, true);
+                window.addEventListener('blur', _this.cancel, false);
             }
         },
         removeMouseHandlers: function () {
-            if (this.mouseHandlersAttached) {
-                this.mouseHandlersAttached = false;
-                document.documentElement.removeEventListener('mouseleave', this.onMouseLeave, false);
-                window.removeEventListener('mousemove', this.onMouseMove, true);
-                window.removeEventListener('mouseup', this.onMouseUp, true);
-                window.removeEventListener('blur', this.cancel, false);
+            if (_this.mouseHandlersAttached) {
+                _this.mouseHandlersAttached = false;
+                document.documentElement.removeEventListener('mouseleave', _this.onMouseLeave, false);
+                window.removeEventListener('mousemove', _this.onMouseMove, true);
+                window.removeEventListener('mouseup', _this.onMouseUp, true);
+                window.removeEventListener('blur', _this.cancel, false);
             }
         },
         onMouseLeave: function (e) {
@@ -734,22 +732,22 @@ exports.Slip = function () {
         onTouchEnd: function (e) {
             e.stopPropagation();
             if (e.touches.length > 1) {
-                this.cancel();
+                _this.cancel();
             }
-            else if (this.state.onEnd && false === this.state.onEnd.call(this)) {
+            else if (_this.state.onEnd && false === _this.state.onEnd.call(_this)) {
                 e.preventDefault();
             }
         },
         getTotalMovement: function () {
-            var scrollOffset = this.target.scrollContainer.scrollTop - this.target.origScrollTop;
+            var scrollOffset = _this.target.scrollContainer.scrollTop - _this.target.origScrollTop;
             return {
-                x: this.latestPosition.x - this.startPosition.x,
-                y: this.latestPosition.y - this.startPosition.y + scrollOffset,
-                time: this.latestPosition.time - this.startPosition.time,
+                x: _this.latestPosition.x - _this.startPosition.x,
+                y: _this.latestPosition.y - _this.startPosition.y + scrollOffset,
+                time: _this.latestPosition.time - _this.startPosition.time,
             };
         },
         getAbsoluteMovement: function () {
-            var move = this.getTotalMovement();
+            var move = _this.getTotalMovement();
             return {
                 x: Math.abs(move.x),
                 y: Math.abs(move.y),
@@ -761,7 +759,7 @@ exports.Slip = function () {
         updateScrolling: function () {
             var triggerOffset = 40;
             var offset = 0;
-            var scrollable = this.target.scrollContainer, containerRect = scrollable.getBoundingClientRect(), targetRect = this.target.node.getBoundingClientRect(), bottomOffset = Math.min(containerRect.bottom, window.innerHeight) - targetRect.bottom, topOffset = targetRect.top - Math.max(containerRect.top, 0), maxScrollTop = this.target.origScrollHeight - Math.min(scrollable.clientHeight, window.innerHeight);
+            var scrollable = _this.target.scrollContainer, containerRect = scrollable.getBoundingClientRect(), targetRect = _this.target.node.getBoundingClientRect(), bottomOffset = Math.min(containerRect.bottom, window.innerHeight) - targetRect.bottom, topOffset = targetRect.top - Math.max(containerRect.top, 0), maxScrollTop = _this.target.origScrollHeight - Math.min(scrollable.clientHeight, window.innerHeight);
             if (bottomOffset < triggerOffset) {
                 offset = Math.min(triggerOffset, triggerOffset - bottomOffset);
             }
@@ -797,17 +795,18 @@ exports.Slip = function () {
         },
         animateToZero: function (callback, target) {
             // save, because this.target/container could change during animation
-            target = target || this.target;
+            target = target || _this.target;
             target.node.style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.1s ease-out';
             target.node.style[transformJSPropertyName] = 'translate(0,0) ' + hwLayerMagicStyle + target.baseTransform.value;
             setTimeout(function () {
                 target.node.style[transitionJSPropertyName] = '';
                 target.node.style[transformJSPropertyName] = target.baseTransform.original;
                 if (callback)
-                    callback.call(this, target);
-            }.bind(this), 101);
+                    callback.call(_this, target);
+            }, 101);
         },
         animateSwipe: function (callback) {
+            var _this = this;
             var target = this.target;
             var siblings = this.getSiblings(target);
             var emptySpaceTransformStyle = 'translate(0,' + this.target.height + 'px) ' + hwLayerMagicStyle + ' ';
@@ -815,7 +814,7 @@ exports.Slip = function () {
             target.node.style[transitionJSPropertyName] = 'all 0.1s linear';
             target.node.style[transformJSPropertyName] = ' translate(' + (this.getTotalMovement().x > 0 ? '' : '-') + '100%,0) ' + hwLayerMagicStyle + target.baseTransform.value;
             setTimeout(function () {
-                if (callback.call(this, target)) {
+                if (callback.call(_this, target)) {
                     siblings.forEach(function (o) {
                         o.node.style[transitionJSPropertyName] = '';
                         o.node.style[transformJSPropertyName] = emptySpaceTransformStyle + o.baseTransform.value;
@@ -833,7 +832,7 @@ exports.Slip = function () {
                         }, 101);
                     }, 1);
                 }
-            }.bind(this), 101);
+            }, 101);
         },
     };
     return Slip;

--- a/slip.ts
+++ b/slip.ts
@@ -254,12 +254,15 @@ export const Slip = function(this: ISlip): ISlip {
                 this.target.node.style.willChange = transformCSSPropertyName;
                 this.target.node.style[transitionJSPropertyName] = '';
 
+                let holdTimer = 0;
+
                 if (!this.dispatch(this.target.originalTarget, 'beforewait')) {
                     if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
                         this.setState(this.states.reorder);
                     }
+
                 } else {
-                    const holdTimer = setTimeout(() => {
+                    holdTimer = setTimeout(() => {
                         const move = this.getAbsoluteMovement();
                         if (this.canPreventScrolling && move.x < 15 && move.y < 25) {
                             if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
@@ -867,7 +870,7 @@ export const Slip = function(this: ISlip): ISlip {
             } else {
                 event = document.createEvent('Event') as CustomEvent<any>;
                 event.initEvent('slip:' + eventName, true, true);
-                event.detail = detail;
+                // event.detail = detail;
             }
             return targetNode.dispatchEvent(event);
         },
@@ -931,5 +934,5 @@ export const Slip = function(this: ISlip): ISlip {
             );
         },
     };
-    return Slip;
+    return Slip as any;
 };

--- a/slip.ts
+++ b/slip.ts
@@ -1,6 +1,6 @@
 /// <reference path="./slip.d.ts" />
 
-import { IOptions, IPosition, ISibling, ISlip, IStateIdle, IStateUndecided, ITarget, ITransform } from './slip.d';
+import { IOptions, IPosition, ISibling, ISlip, ITarget, ITransform } from './slip.d';
 
 /*
     Slip - swiping and reordering in lists of elements on touch screens, no fuss.
@@ -91,6 +91,7 @@ import { IOptions, IPosition, ISibling, ISlip, IStateIdle, IStateUndecided, ITar
     Caveats:
         • Elements must not change size while reordering or swiping takes place (otherwise it will be visually out of sync)
 */
+
 /*! @license
     Slip.js 1.2.0
 
@@ -113,8 +114,48 @@ import { IOptions, IPosition, ISibling, ISlip, IStateIdle, IStateUndecided, ITar
     USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-export const Slip = function(this: ISlip): ISlip {
-    const accessibility = {
+export class Slip implements ISlip {
+    private static nullHandler = function() {};
+    getTransform = (node: HTMLElement): ITransform => {
+        const transform = node.style[transformJSPropertyName];
+        if (transform) {
+            return {
+                value: transform,
+                original: transform,
+            };
+        }
+
+        if (window.getComputedStyle) {
+            const style = window.getComputedStyle(node).getPropertyValue(transformCSSPropertyName);
+            if (style && style !== 'none') return { value: style, original: '' };
+        }
+        return { value: '', original: '' };
+    };
+    findIndex = (target: {node: HTMLElement}, nodes: NodeListOf<Node & ChildNode>): number => {
+        let originalIndex = 0;
+        let listCount = 0;
+
+        for (let i = 0; i < nodes.length; i++) {
+            if (nodes[i].nodeType === 1) {
+                listCount++;
+                if (nodes[i] === target.node) {
+                    originalIndex = listCount - 1;
+                }
+            }
+        }
+
+        return originalIndex;
+    };
+    container!: HTMLElement;
+    state: null;
+    target!: ITarget; // the tapped/swiped/reordered node with height and backed up styles
+    usingTouch: false; // there's no good way to detect touchscreen preference other than receiving a touch event (really, trust me).
+    mouseHandlersAttached: false;
+    startPosition: null; // x,y,time where first touch began
+    latestPosition: null; // x,y,time where the finger is currently
+    previousPosition: null; // x,y,time where the finger was ~100ms ago (for velocity calculation)
+    canPreventScrolling: false;
+    private accessibility = {
         // Set values to false if you don't want Slip to manage them
         container: {
             ariaRole: 'listbox',
@@ -127,32 +168,25 @@ export const Slip = function(this: ISlip): ISlip {
             focus: false, // focuses when dragging
         },
     };
-
-    const damnYouChrome = /Chrome\/[3-5]/.test(navigator.userAgent); // For bugs that can't be programmatically detected :( Intended to catch all versions of Chrome 30-40
-    const needsBodyHandlerHack = damnYouChrome; // Otherwise I _sometimes_ don't get any touchstart events and only clicks instead.
-
+    private damnYouChrome = /Chrome\/[3-5]/.test(navigator.userAgent); // For bugs that can't be programmatically detected :( Intended to catch all versions of Chrome 30-40
+    private needsBodyHandlerHack = this.damnYouChrome; // Otherwise I _sometimes_ don't get any touchstart events and only clicks instead.
     /* When dragging elements down in Chrome (tested 34-37) dragged element may appear below stationary elements.
        Looks like WebKit bug #61824, but iOS Safari doesn't have that problem. */
-    const compositorDoesNotOrderLayers = damnYouChrome;
-
+    private compositorDoesNotOrderLayers = this.damnYouChrome;
     // -webkit-mess
-    let testElementStyle: CSSStyleDeclaration | null = document.createElement('div').style;
+    private testElementStyle: CSSStyleDeclaration = document.createElement('div').style;
+    private transformCSSPropertyName = this.transformJSPropertyName === 'webkitTransform' ? '-webkit-transform' : 'transform';
+    private testElementStyle = null;
+    private transitionJSPropertyName = 'transition'.indexOf(this.testElementStyle.toString()) > -1 ? 'transition' : 'webkitTransition';
+    private transformJSPropertyName: string = 'transform'.indexOf(this.testElementStyle.toString()) > -1 ? 'transform' : 'webkitTransform';
+    private userSelectJSPropertyName = 'userSelect'.indexOf(this.testElementStyle.toString()) > -1 ? 'userSelect' : 'webkitUserSelect';
+    private hwLayerMagicStyle = this.testElementStyle[this.transformJSPropertyName] ? 'translateZ(0) ' : '';
+    private hwTopLayerMagicStyle = this.testElementStyle[this.transformJSPropertyName] ? 'translateZ(1px) ' : '';
+    private globalInstances = 0;
+    private attachedBodyHandlerHack = false;
 
-    const transitionJSPropertyName = 'transition' in testElementStyle ? 'transition' : 'webkitTransition';
-    const transformJSPropertyName = 'transform' in testElementStyle ? 'transform' : 'webkitTransform';
-    const transformCSSPropertyName = transformJSPropertyName === 'webkitTransform' ? '-webkit-transform' : 'transform';
-    const userSelectJSPropertyName = 'userSelect' in testElementStyle ? 'userSelect' : 'webkitUserSelect';
-
-    testElementStyle[transformJSPropertyName] = 'translateZ(0)';
-    const hwLayerMagicStyle = testElementStyle[transformJSPropertyName] ? 'translateZ(0) ' : '';
-    const hwTopLayerMagicStyle = testElementStyle[transformJSPropertyName] ? 'translateZ(1px) ' : '';
-    testElementStyle = null;
-
-    let globalInstances = 0;
-    let attachedBodyHandlerHack = false;
-    const nullHandler = function() {};
-
-    const Slip = function(this: ISlip, container: HTMLElement | null, options: IOptions) {
+    constructor(private container: HTMLElement | null, private options: IOptions) {
+        this.testElementStyle[this.transformJSPropertyName as string] = 'translateZ(0)';
         if ('string' === typeof (container as any as string))
             container = document.querySelector<HTMLElement>(container as any as string);
         if (!container || !container.addEventListener) throw new Error('Please specify DOM node to attach to');
@@ -183,90 +217,52 @@ export const Slip = function(this: ISlip): ISlip {
         this.attach(container);
 
         return this;
-    } as any as {new(container: HTMLElement | null, options: IOptions): ISlip;};
+    }
 
-    const getTransform = (node: HTMLElement): ITransform => {
-        const transform = node.style[transformJSPropertyName];
-        if (transform) {
-            return {
-                value: transform,
-                original: transform,
-            };
-        }
+    get states() {
+        let outer = this;
 
-        if (window.getComputedStyle) {
-            const style = window.getComputedStyle(node).getPropertyValue(transformCSSPropertyName);
-            if (style && style !== 'none') return { value: style, original: '' };
-        }
-        return { value: '', original: '' };
-    };
+        const states = class {
+            constructor(private state: 'idle' | 'undecided' | 'swipe' | 'reorder') {}
 
-    const findIndex = (target: {node: HTMLElement}, nodes: NodeListOf<Node & ChildNode>): number => {
-        let originalIndex = 0;
-        let listCount = 0;
+            init() {
+                switch (this.state) {
+                    case 'idle':
+                        this.idle();
+                        outer.usingTouch = false;
 
-        for (let i = 0; i < nodes.length; i++) {
-            if (nodes[i].nodeType === 1) {
-                listCount++;
-                if (nodes[i] === target.node) {
-                    originalIndex = listCount - 1;
+                        return {
+                            allowTextSelection: true,
+                        };
                 }
             }
-        }
 
-        return originalIndex;
-    };
-
-    // All functions in states are going to be executed in context of Slip object
-    Slip.prototype = {
-
-        container: null,
-        options: {},
-        state: null,
-
-        target: null, // the tapped/swiped/reordered node with height and backed up styles
-
-        usingTouch: false, // there's no good way to detect touchscreen preference other than receiving a touch event (really, trust me).
-        mouseHandlersAttached: false,
-
-        startPosition: null, // x,y,time where first touch began
-        latestPosition: null, // x,y,time where the finger is currently
-        previousPosition: null, // x,y,time where the finger was ~100ms ago (for velocity calculation)
-
-        canPreventScrolling: false,
-
-        states: {
-            idle: function idleStateInit(this: IStateIdle) {
-                this.removeMouseHandlers();
-                if (this.target) {
-                    this.target.node.style.willChange = '';
-                    this.target = null;
+            idle() {
+                outer.removeMouseHandlers();
+                if (outer.target) {
+                    outer.target.node.style.willChange = '';
+                    outer.target = null;
                 }
-                this.usingTouch = false;
+            }
 
-                return {
-                    allowTextSelection: true,
-                };
-            },
-
-            undecided: function undecidedStateInit(this: IStateUndecided) {
-                this.target.height = this.target.node.offsetHeight;
-                this.target.node.style.willChange = transformCSSPropertyName;
-                this.target.node.style[transitionJSPropertyName] = '';
+            undecided() {
+                outer.target.height = outer.target.node.offsetHeight;
+                outer.target.node.style.willChange = transformCSSPropertyName;
+                outer.target.node.style[transitionJSPropertyName] = '';
 
                 let holdTimer = 0;
 
-                if (!this.dispatch(this.target.originalTarget, 'beforewait')) {
-                    if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
-                        this.setState(this.states.reorder);
+                if (!outer.dispatch(outer.target.originalTarget, 'beforewait')) {
+                    if (outer.dispatch(outer.target.originalTarget, 'beforereorder')) {
+                        outer.setState(outer.states.reorder);
                     }
 
                 } else {
                     holdTimer = setTimeout(() => {
-                        const move = this.getAbsoluteMovement();
-                        if (this.canPreventScrolling && move.x < 15 && move.y < 25) {
-                            if (this.dispatch(this.target.originalTarget, 'beforereorder')) {
-                                this.setState(this.states.reorder);
+                        const move = outer.getAbsoluteMovement();
+                        if (outer.canPreventScrolling && move.x < 15 && move.y < 25) {
+                            if (outer.dispatch(outer.target.originalTarget, 'beforereorder')) {
+                                outer.setState(outer.states.reorder);
                             }
                         }
                     }, 300);
@@ -275,120 +271,120 @@ export const Slip = function(this: ISlip): ISlip {
                 return {
                     leaveState: () => clearTimeout(holdTimer),
                     onMove: () => {
-                        const move = this.getAbsoluteMovement();
+                        const move = outer.getAbsoluteMovement();
 
-                        if (move.x > 20 && move.y < Math.max(100, this.target.height || 0)) {
-                            if (this.dispatch(this.target.originalTarget, 'beforeswipe', {
+                        if (move.x > 20 && move.y < Math.max(100, outer.target.height || 0)) {
+                            if (outer.dispatch(outer.target.originalTarget, 'beforeswipe', {
                                 directionX: move.directionX,
                                 directionY: move.directionY
                             })) {
-                                this.setState(this.states.swipe);
+                                outer.setState(outer.states.swipe);
                                 return false;
                             } else {
-                                this.setState(this.states.idle);
+                                outer.setState(outer.states.idle);
                             }
                         }
                         if (move.y > 20) {
-                            this.setState(this.states.idle);
+                            outer.setState(outer.states.idle);
                         }
 
                         // Chrome likes sideways scrolling :(
                         if (move.x > move.y * 1.2) return false;
                     },
 
-                    onLeave: () => this.setState(this.states.idle),
+                    onLeave: () => outer.setState(outer.states.idle),
                     onEnd: () => {
-                        const allowDefault = this.dispatch(this.target.originalTarget, 'tap');
-                        this.setState(this.states.idle);
+                        const allowDefault = outer.dispatch(outer.target.originalTarget, 'tap');
+                        outer.setState(outer.states.idle);
                         return allowDefault;
                     },
                 };
-            },
+            }
 
-            swipe: () => {
+            swipe() {
                 let swipeSuccess = false;
-                const container = this.container;
+                const container = outer.container;
 
-                const originalIndex = findIndex(this.target, this.container.childNodes);
+                const originalIndex = findIndex(outer.target, outer.container.childNodes);
 
                 container.classList.add('slip-swiping-container');
 
                 const removeClass = () => container.classList.remove('slip-swiping-container');
 
-                this.target.height = this.target.node.offsetHeight;
+                outer.target.height = outer.target.node.offsetHeight;
 
                 return {
                     leaveState: () => {
                         if (swipeSuccess) {
-                            this.animateSwipe(target => {
+                            outer.animateSwipe(target => {
                                 target.node.style[transformJSPropertyName] = target.baseTransform.original;
                                 target.node.style[transitionJSPropertyName] = '';
-                                if (this.dispatch(target.node, 'afterswipe')) {
+                                if (outer.dispatch(target.node, 'afterswipe')) {
                                     removeClass();
                                     return true;
                                 } else {
-                                    this.animateToZero(undefined, target);
+                                    outer.animateToZero(undefined, target);
                                 }
                             });
                         } else {
-                            this.animateToZero(removeClass);
+                            outer.animateToZero(removeClass);
                         }
                     },
 
                     onMove: () => {
-                        const move = this.getTotalMovement();
+                        const move = outer.getTotalMovement();
 
-                        if (this.target.height && Math.abs(move.y) < this.target.height + 20) {
-                            if (this.dispatch(this.target.node, 'animateswipe', {
+                        if (outer.target.height && Math.abs(move.y) < outer.target.height + 20) {
+                            if (outer.dispatch(outer.target.node, 'animateswipe', {
                                 x: move.x,
                                 originalIndex: originalIndex
                             })) {
-                                this.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + this.target.baseTransform.value;
+                                outer.target.node.style[transformJSPropertyName] = 'translate(' + move.x + 'px,0) ' + hwLayerMagicStyle + outer.target.baseTransform.value;
                             }
                             return false;
                         } else {
-                            this.dispatch(this.target.node, 'cancelswipe');
-                            this.setState(this.states.idle);
+                            outer.dispatch(outer.target.node, 'cancelswipe');
+                            outer.setState(outer.states.idle);
                         }
                     },
 
-                    onLeave: this.state.onEnd,
+                    onLeave: outer.state.onEnd,
 
                     onEnd: () => {
-                        const move = this.getAbsoluteMovement();
+                        const move = outer.getAbsoluteMovement();
                         const velocity = move.x / move.time;
 
                         // How far out has the item been swiped?
-                        const swipedPercent = Math.abs((this.startPosition.x - this.previousPosition.x) / this.container.clientWidth) * 100;
+                        const swipedPercent = Math.abs((outer.startPosition.x - outer.previousPosition.x) / outer.container.clientWidth) * 100;
 
-                        const swiped = (velocity > this.options.minimumSwipeVelocity && move.time > this.options.minimumSwipeTime) || (this.options.keepSwipingPercent && swipedPercent > this.options.keepSwipingPercent);
+                        const swiped = (velocity > outer.options.minimumSwipeVelocity && move.time > outer.options.minimumSwipeTime) || (outer.options.keepSwipingPercent && swipedPercent > outer.options.keepSwipingPercent);
 
                         if (swiped) {
-                            if (this.dispatch(this.target.node, 'swipe', {
+                            if (outer.dispatch(outer.target.node, 'swipe', {
                                 direction: move.directionX,
                                 originalIndex: originalIndex
                             })) {
                                 swipeSuccess = true; // can't animate here, leaveState overrides anim
                             }
                         } else {
-                            this.dispatch(this.target.node, 'cancelswipe');
+                            outer.dispatch(outer.target.node, 'cancelswipe');
                         }
-                        this.setState(this.states.idle);
+                        outer.setState(outer.states.idle);
                         return !swiped;
                     },
                 };
-            },
+            }
 
-            reorder: () => {
-                if (this.target.node.focus && accessibility.items.focus) {
-                    this.target.node.focus();
+            reorder() {
+                if (outer.target.node.focus && accessibility.items.focus) {
+                    outer.target.node.focus();
                 }
 
-                this.target.height = this.target.node.offsetHeight;
+                outer.target.height = outer.target.node.offsetHeight;
 
                 let nodes: NodeListOf<Node & ChildNode>;
-                if (this.options.ignoredElements.length) {
-                    const container = this.container;
+                if (outer.options.ignoredElements.length) {
+                    const container = outer.container;
                     let query = container.tagName.toLowerCase();
                     if (container.getAttribute('id')) {
                         query = '#' + container.getAttribute('id');
@@ -397,7 +393,7 @@ export const Slip = function(this: ISlip): ISlip {
                             .replace(' ', '.');
                     }
                     query += ' > ';
-                    this.options.ignoredElements.forEach((selector) => {
+                    outer.options.ignoredElements.forEach((selector) => {
                         query += ':not(' + selector + ')';
                     });
                     try {
@@ -409,14 +405,14 @@ export const Slip = function(this: ISlip): ISlip {
                             throw err;
                     }
                 } else {
-                    nodes = this.container.childNodes as NodeListOf<Node & ChildNode>;
+                    nodes = outer.container.childNodes as NodeListOf<Node & ChildNode>;
                 }
-                const originalIndex = findIndex(this.target, nodes);
+                const originalIndex = findIndex(outer.target, nodes);
                 let mouseOutsideTimer: number | null;
-                const zero = this.target.node.offsetTop + this.target.height / 2;
+                const zero = outer.target.node.offsetTop + outer.target.height / 2;
                 const otherNodes: {node: Node & ChildNode, baseTransform: ITransform, pos: number}[] = [];
                 for (let i = 0; i < nodes.length; i++) {
-                    if (nodes[i].nodeType != 1 || nodes[i] === this.target.node) continue;
+                    if (nodes[i].nodeType != 1 || nodes[i] === outer.target.node) continue;
                     const t = (nodes[i] as HTMLElement).offsetTop;
                     (nodes[i] as HTMLElement).style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.2s ease-in-out';
                     otherNodes.push({
@@ -426,18 +422,18 @@ export const Slip = function(this: ISlip): ISlip {
                     });
                 }
 
-                this.target.node.classList.add('slip-reordering');
-                this.target.node.style.zIndex = '99999';
-                this.target.node.style[userSelectJSPropertyName] = 'none';
+                outer.target.node.classList.add('slip-reordering');
+                outer.target.node.style.zIndex = '99999';
+                outer.target.node.style[userSelectJSPropertyName] = 'none';
                 if (compositorDoesNotOrderLayers) {
                     // Chrome's compositor doesn't sort 2D layers
-                    this.container.style.webkitTransformStyle = 'preserve-3d';
+                    outer.container.style.webkitTransformStyle = 'preserve-3d';
                 }
 
                 const onMove = () => {
                     /*jshint validthis:true */
 
-                    this.updateScrolling();
+                    outer.updateScrolling();
 
                     if (mouseOutsideTimer) {
                         // don't care where the mouse is as long as it moves
@@ -445,10 +441,10 @@ export const Slip = function(this: ISlip): ISlip {
                         mouseOutsideTimer = null;
                     }
 
-                    const move = this.getTotalMovement();
-                    this.target.node.style[transformJSPropertyName] = 'translate(0,' + move.y + 'px) ' + hwTopLayerMagicStyle + this.target.baseTransform.value;
+                    const move = outer.getTotalMovement();
+                    outer.target.node.style[transformJSPropertyName] = 'translate(0,' + move.y + 'px) ' + hwTopLayerMagicStyle + outer.target.baseTransform.value;
 
-                    const height = this.target.height || 0;
+                    const height = outer.target.height || 0;
                     otherNodes.forEach(function(o) {
                         let off = 0;
                         if (o.pos < 0 && move.y < 0 && o.pos > move.y) {
@@ -470,17 +466,17 @@ export const Slip = function(this: ISlip): ISlip {
                         if (mouseOutsideTimer) clearTimeout(mouseOutsideTimer);
 
                         if (compositorDoesNotOrderLayers) {
-                            this.container.style.webkitTransformStyle = '';
+                            outer.container.style.webkitTransformStyle = '';
                         }
 
-                        if (this.container.focus && accessibility.container.focus) {
-                            this.container.focus();
+                        if (outer.container.focus && accessibility.container.focus) {
+                            outer.container.focus();
                         }
 
-                        this.target.node.classList.remove('slip-reordering');
-                        this.target.node.style[userSelectJSPropertyName] = '';
+                        outer.target.node.classList.remove('slip-reordering');
+                        outer.target.node.style[userSelectJSPropertyName] = '';
 
-                        this.animateToZero((target: ITarget) => target.node.style.zIndex = '');
+                        outer.animateToZero((target: ITarget) => target.node.style.zIndex = '');
                         otherNodes.forEach(o => {
                             (o.node as HTMLElement).style[transformJSPropertyName] = o.baseTransform.original;
                             (o.node as HTMLElement).style[transitionJSPropertyName] = ''; // FIXME: animate to new position
@@ -495,14 +491,14 @@ export const Slip = function(this: ISlip): ISlip {
                         if (mouseOutsideTimer) clearTimeout(mouseOutsideTimer);
                         mouseOutsideTimer = setTimeout(() => {
                                 mouseOutsideTimer = null;
-                                this.cancel();
+                            outer.cancel();
                             }, 700
                         )
                         ;
                     },
 
                     onEnd: () => {
-                        const move = this.getTotalMovement();
+                        const move = outer.getTotalMovement();
                         let i, spliceIndex;
                         if (move.y < 0) {
                             for (i = 0; i < otherNodes.length; i++) {
@@ -520,419 +516,421 @@ export const Slip = function(this: ISlip): ISlip {
                             spliceIndex = i + 1;
                         }
 
-                        this.dispatch(this.target.node, 'reorder', {
+                        outer.dispatch(outer.target.node, 'reorder', {
                             spliceIndex: spliceIndex,
                             originalIndex: originalIndex,
                             insertBefore: otherNodes[spliceIndex] ? (otherNodes[spliceIndex] as any).node : undefined,
                         });
 
-                        this.setState(this.states.idle);
+                        outer.setState(outer.states.idle);
                         return false;
                     },
                 };
-            },
-        },
-
-        attach: (container: HTMLElement) => {
-            globalInstances++;
-            if (this.container) this.detach();
-
-            // In some cases taps on list elements send *only* click events and no touch events. Spotted only in Chrome 32+
-            // Having event listener on body seems to solve the issue (although AFAIK may disable smooth scrolling as a side-effect)
-            if (!attachedBodyHandlerHack && needsBodyHandlerHack) {
-                attachedBodyHandlerHack = true;
-                document.body.addEventListener('touchstart', nullHandler, false);
             }
+        }
+    }
 
-            this.container = container;
+    attach(container: HTMLElement) {
+        globalInstances++;
+        if (this.container) this.detach();
 
-            // Accessibility
-            if (false !== accessibility.container.tabIndex as any as boolean) {
-                this.container.tabIndex = accessibility.container.tabIndex;
+        // In some cases taps on list elements send *only* click events and no touch events. Spotted only in Chrome 32+
+        // Having event listener on body seems to solve the issue (although AFAIK may disable smooth scrolling as a side-effect)
+        if (!attachedBodyHandlerHack && needsBodyHandlerHack) {
+            attachedBodyHandlerHack = true;
+            document.body.addEventListener('touchstart', nullHandler, false);
+        }
+
+        this.container = container;
+
+        // Accessibility
+        if (false !== accessibility.container.tabIndex as any as boolean) {
+            this.container.tabIndex = accessibility.container.tabIndex;
+        }
+        if (accessibility.container.ariaRole) {
+            this.container.setAttribute('aria-role', accessibility.container.ariaRole);
+        }
+        this.setChildNodesAriaRoles();
+        this.container.addEventListener('focus', this.onContainerFocus, false);
+
+        this.otherNodes = [];
+
+        // selection on iOS interferes with reordering
+        document.addEventListener('selectionchange', this.onSelection, false);
+
+        // cancel is called e.g. when iOS detects multitasking gesture
+        this.container.addEventListener('touchcancel', this.cancel, false);
+        this.container.addEventListener('touchstart', this.onTouchStart, false);
+        this.container.addEventListener('touchmove', this.onTouchMove, false);
+        this.container.addEventListener('touchend', this.onTouchEnd, false);
+        this.container.addEventListener('mousedown', this.onMouseDown, false);
+        // mousemove and mouseup are attached dynamically
+    }
+
+    detach() {
+        this.cancel();
+
+        this.container.removeEventListener('mousedown', this.onMouseDown, false);
+        this.container.removeEventListener('touchend', this.onTouchEnd, false);
+        this.container.removeEventListener('touchmove', this.onTouchMove, false);
+        this.container.removeEventListener('touchstart', this.onTouchStart, false);
+        this.container.removeEventListener('touchcancel', this.cancel, false);
+
+        document.removeEventListener('selectionchange', this.onSelection, false);
+
+        if (false !== accessibility.container.tabIndex as any as boolean) {
+            this.container.removeAttribute('tabIndex');
+        }
+        if (accessibility.container.ariaRole) {
+            this.container.removeAttribute('aria-role');
+        }
+        this.unSetChildNodesAriaRoles();
+
+        globalInstances--;
+        if (!globalInstances && attachedBodyHandlerHack) {
+            attachedBodyHandlerHack = false;
+            document.body.removeEventListener('touchstart', nullHandler, false);
+        }
+    }
+
+    setState(newStateCtor: {new(): any}) {
+        if (this.state) {
+            if (this.state.ctor === newStateCtor) return;
+            if (this.state.leaveState) this.state.leaveState.call(this);
+        }
+
+        // Must be re-entrant in case ctor changes state
+        const prevState = this.state;
+        const nextState = newStateCtor.call(this);
+        if (this.state === prevState) {
+            nextState.ctor = newStateCtor;
+            this.state = nextState;
+        }
+    }
+
+    findTargetNode(targetNode: Node | null): Node | null {
+        while (targetNode && targetNode.parentNode !== this.container) {
+            if (targetNode.parentNode != null)
+                targetNode = targetNode.parentNode;
+        }
+        return targetNode;
+    }
+
+    onContainerFocus(e: TouchEvent) {
+        e.stopPropagation();
+        this.setChildNodesAriaRoles();
+    }
+
+    setChildNodesAriaRoles() {
+        const nodes = this.container.childNodes as NodeListOf<HTMLElement>;
+        for (let i = 0; i < nodes.length; i++) {
+            if (nodes[i].nodeType != 1) continue;
+            if (accessibility.items.ariaRole) {
+                nodes[i].setAttribute('aria-role', accessibility.items.ariaRole);
             }
-            if (accessibility.container.ariaRole) {
-                this.container.setAttribute('aria-role', accessibility.container.ariaRole);
+            if (false !== accessibility.items.tabIndex as any as boolean) {
+                nodes[i].tabIndex = accessibility.items.tabIndex;
             }
-            this.setChildNodesAriaRoles();
-            this.container.addEventListener('focus', this.onContainerFocus, false);
+        }
+    }
 
-            this.otherNodes = [];
+    unSetChildNodesAriaRoles() {
+        const nodes = this.container.childNodes as NodeListOf<HTMLElement>;
+        for (let i = 0; i < nodes.length; i++) {
+            if (nodes[i].nodeType != 1) continue;
+            if (accessibility.items.ariaRole) {
+                nodes[i].removeAttribute('aria-role');
+            }
+            if (false !== accessibility.items.tabIndex as any as boolean) {
+                nodes[i].removeAttribute('tabIndex');
+            }
+        }
+    }
 
-            // selection on iOS interferes with reordering
-            document.addEventListener('selectionchange', this.onSelection, false);
+    onSelection(e: Event & Node) {
+        e.stopPropagation();
+        const isRelated = e.target === document || this.findTargetNode(e);
+        const iOS = /(iPhone|iPad|iPod)/i.test(navigator.userAgent) && !/(Android|Windows)/i.test(navigator.userAgent);
+        if (!isRelated) return;
 
-            // cancel is called e.g. when iOS detects multitasking gesture
-            this.container.addEventListener('touchcancel', this.cancel, false);
-            this.container.addEventListener('touchstart', this.onTouchStart, false);
-            this.container.addEventListener('touchmove', this.onTouchMove, false);
-            this.container.addEventListener('touchend', this.onTouchEnd, false);
-            this.container.addEventListener('mousedown', this.onMouseDown, false);
-            // mousemove and mouseup are attached dynamically
-        },
+        if (iOS) {
+            // iOS doesn't allow selection to be prevented
+            this.setState(this.states.idle);
+        } else {
+            if (!this.state.allowTextSelection) {
+                e.preventDefault();
+            }
+        }
+    }
 
-        detach: () => {
+    addMouseHandlers() {
+        // unlike touch events, mousemove/up is not conveniently fired on the same element,
+        // but I don't need to listen to unrelated events all the time
+        if (!this.mouseHandlersAttached) {
+            this.mouseHandlersAttached = true;
+            document.documentElement.addEventListener('mouseleave', this.onMouseLeave, false);
+            window.addEventListener('mousemove', this.onMouseMove, true);
+            window.addEventListener('mouseup', this.onMouseUp, true);
+            window.addEventListener('blur', this.cancel, false);
+        }
+    }
+
+    removeMouseHandlers() {
+        if (this.mouseHandlersAttached) {
+            this.mouseHandlersAttached = false;
+            document.documentElement.removeEventListener('mouseleave', this.onMouseLeave, false);
+            window.removeEventListener('mousemove', this.onMouseMove, true);
+            window.removeEventListener('mouseup', this.onMouseUp, true);
+            window.removeEventListener('blur', this.cancel, false);
+        }
+    }
+
+    onMouseLeave(e: MouseEvent) {
+        e.stopPropagation();
+        if (this.usingTouch) return;
+
+        if (e.target === document.documentElement || e.relatedTarget === document.documentElement) {
+            if (this.state.onLeave) {
+                this.state.onLeave.call(this);
+            }
+        }
+    }
+
+    onMouseDown(e: MouseEvent & MSGesture) {
+        e.stopPropagation();
+        if (this.usingTouch || e.button != 0 || !this.setTarget(e)) return;
+
+        this.addMouseHandlers(); // mouseup, etc.
+
+        this.canPreventScrolling = true; // or rather it doesn't apply to mouse
+
+        this.startAtPosition({
+            x: e.clientX,
+            y: e.clientY,
+            time: e.timeStamp,
+        });
+    }
+
+    onTouchStart(e: TouchEvent) {
+        e.stopPropagation();
+        this.usingTouch = true;
+        this.canPreventScrolling = true;
+
+        // This implementation cares only about single touch
+        if (e.touches.length > 1) {
+            this.setState(this.states.idle);
+            return;
+        }
+
+        if (e.target != null && !this.setTarget(e)) return;
+
+        this.startAtPosition({
+            x: e.touches[0].clientX,
+            y: e.touches[0].clientY,
+            time: e.timeStamp,
+        });
+    }
+
+    setTarget(e: Event & {target?: Node | null}): boolean {
+        const targetNode = this.findTargetNode(e.target);
+        if (!targetNode) {
+            this.setState(this.states.idle);
+            return false;
+        }
+
+        //check for a scrollable parent
+        let scrollContainer = targetNode.parentNode as HTMLElement;
+        while (scrollContainer) {
+            if (scrollContainer == document.body) break;
+            if (scrollContainer.scrollHeight > scrollContainer.clientHeight && window.getComputedStyle(scrollContainer).overflowY !== 'visible') break;
+            scrollContainer = scrollContainer.parentNode as HTMLElement;
+        }
+        scrollContainer = scrollContainer || document.body;
+
+        this.target = {
+            originalTarget: e.target as any as ITarget,
+            node: targetNode as ITarget['node'],
+            scrollContainer: scrollContainer,
+            origScrollTop: scrollContainer.scrollTop,
+            origScrollHeight: scrollContainer.scrollHeight,
+            baseTransform: getTransform(targetNode as HTMLElement),
+        };
+        return true;
+    }
+
+    startAtPosition(pos: IPosition) {
+        this.startPosition = this.previousPosition = this.latestPosition = pos;
+        this.setState(this.states.undecided);
+    }
+
+    updatePosition(e: MouseEvent | TouchEvent, pos: IPosition) {
+        if (this.target == null) {
+            return;
+        }
+        this.latestPosition = pos;
+
+        if (this.state.onMove) {
+            if (this.state.onMove.call(this) === false) {
+                e.preventDefault();
+            }
+        }
+
+        // sample latestPosition 100ms for velocity
+        if (this.latestPosition.time - this.previousPosition.time > 100) {
+            this.previousPosition = this.latestPosition;
+        }
+    }
+
+    onMouseMove(e: MouseEvent) {
+        e.stopPropagation();
+        this.updatePosition(e, {
+            x: e.clientX,
+            y: e.clientY,
+            time: e.timeStamp,
+        });
+    }
+
+    onTouchMove(e: TouchEvent) {
+        e.stopPropagation();
+        this.updatePosition(e, {
+            x: e.touches[0].clientX,
+            y: e.touches[0].clientY,
+            time: e.timeStamp,
+        });
+
+        // In Apple's touch model only the first move event after touchstart can prevent scrolling (and event.cancelable is broken)
+        this.canPreventScrolling = false;
+    }
+
+    onMouseUp(e: MouseEvent) {
+        e.stopPropagation();
+        if (this.usingTouch || e.button !== 0) return;
+
+        if (this.state.onEnd && false === this.state.onEnd.call(this)) {
+            e.preventDefault();
+        }
+    }
+
+    onTouchEnd(e: TouchEvent) {
+        e.stopPropagation();
+        if (e.touches.length > 1) {
             this.cancel();
+        } else if (this.state.onEnd && false === this.state.onEnd.call(this)) {
+            e.preventDefault();
+        }
+    }
 
-            this.container.removeEventListener('mousedown', this.onMouseDown, false);
-            this.container.removeEventListener('touchend', this.onTouchEnd, false);
-            this.container.removeEventListener('touchmove', this.onTouchMove, false);
-            this.container.removeEventListener('touchstart', this.onTouchStart, false);
-            this.container.removeEventListener('touchcancel', this.cancel, false);
+    getTotalMovement(): ISlip['latestPosition'] {
+        const scrollOffset = this.target.scrollContainer.scrollTop - this.target.origScrollTop;
+        return {
+            x: this.latestPosition.x - this.startPosition.x,
+            y: this.latestPosition.y - this.startPosition.y + scrollOffset,
+            time: this.latestPosition.time - this.startPosition.time,
+        };
+    }
 
-            document.removeEventListener('selectionchange', this.onSelection, false);
+    getAbsoluteMovement() {
+        const move = this.getTotalMovement();
+        return {
+            x: Math.abs(move.x),
+            y: Math.abs(move.y),
+            time: move.time,
+            directionX: move.x < 0 ? 'left' : 'right',
+            directionY: move.y < 0 ? 'up' : 'down',
+        };
+    }
 
-            if (false !== accessibility.container.tabIndex as any as boolean) {
-                this.container.removeAttribute('tabIndex');
-            }
-            if (accessibility.container.ariaRole) {
-                this.container.removeAttribute('aria-role');
-            }
-            this.unSetChildNodesAriaRoles();
+    updateScrolling() {
+        const triggerOffset = 40;
+        let offset = 0;
 
-            globalInstances--;
-            if (!globalInstances && attachedBodyHandlerHack) {
-                attachedBodyHandlerHack = false;
-                document.body.removeEventListener('touchstart', nullHandler, false);
-            }
-        },
+        const scrollable = this.target.scrollContainer,
+            containerRect = scrollable.getBoundingClientRect(),
+            targetRect = this.target.node.getBoundingClientRect(),
+            bottomOffset = Math.min(containerRect.bottom, window.innerHeight) - targetRect.bottom,
+            topOffset = targetRect.top - Math.max(containerRect.top, 0),
+            maxScrollTop = this.target.origScrollHeight - Math.min(scrollable.clientHeight, window.innerHeight);
 
-        setState: (newStateCtor: {new(): any}) => {
-            if (this.state) {
-                if (this.state.ctor === newStateCtor) return;
-                if (this.state.leaveState) this.state.leaveState.call(this);
-            }
+        if (bottomOffset < triggerOffset) {
+            offset = Math.min(triggerOffset, triggerOffset - bottomOffset);
+        }
+        else if (topOffset < triggerOffset) {
+            offset = Math.max(-triggerOffset, topOffset - triggerOffset);
+        }
 
-            // Must be re-entrant in case ctor changes state
-            const prevState = this.state;
-            const nextState = newStateCtor.call(this);
-            if (this.state === prevState) {
-                nextState.ctor = newStateCtor;
-                this.state = nextState;
-            }
-        },
+        scrollable.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollable.scrollTop + offset));
+    }
 
-        findTargetNode: (targetNode: Node | null): Node | null => {
-            while (targetNode && targetNode.parentNode !== this.container) {
-                if (targetNode.parentNode != null)
-                    targetNode = targetNode.parentNode;
-            }
-            return targetNode;
-        },
+    dispatch(targetNode: EventTarget, eventName: string, detail: any) {
+        let event = document.createEvent('CustomEvent');
+        if (event && event.initCustomEvent) {
+            event.initCustomEvent('slip:' + eventName, true, true, detail);
+        } else {
+            event = document.createEvent('Event') as CustomEvent<any>;
+            event.initEvent('slip:' + eventName, true, true);
+            // event.detail = detail;
+        }
+        return targetNode.dispatchEvent(event);
+    }
 
-        onContainerFocus: (e: TouchEvent) => {
-            e.stopPropagation();
-            this.setChildNodesAriaRoles();
-        },
-
-        setChildNodesAriaRoles: () => {
-            const nodes = this.container.childNodes as NodeListOf<HTMLElement>;
-            for (let i = 0; i < nodes.length; i++) {
-                if (nodes[i].nodeType != 1) continue;
-                if (accessibility.items.ariaRole) {
-                    nodes[i].setAttribute('aria-role', accessibility.items.ariaRole);
-                }
-                if (false !== accessibility.items.tabIndex as any as boolean) {
-                    nodes[i].tabIndex = accessibility.items.tabIndex;
-                }
-            }
-        },
-
-        unSetChildNodesAriaRoles: () => {
-            const nodes = this.container.childNodes as NodeListOf<HTMLElement>;
-            for (let i = 0; i < nodes.length; i++) {
-                if (nodes[i].nodeType != 1) continue;
-                if (accessibility.items.ariaRole) {
-                    nodes[i].removeAttribute('aria-role');
-                }
-                if (false !== accessibility.items.tabIndex as any as boolean) {
-                    nodes[i].removeAttribute('tabIndex');
-                }
-            }
-        },
-        onSelection: (e: Event & Node) => {
-            e.stopPropagation();
-            const isRelated = e.target === document || this.findTargetNode(e);
-            const iOS = /(iPhone|iPad|iPod)/i.test(navigator.userAgent) && !/(Android|Windows)/i.test(navigator.userAgent);
-            if (!isRelated) return;
-
-            if (iOS) {
-                // iOS doesn't allow selection to be prevented
-                this.setState(this.states.idle);
-            } else {
-                if (!this.state.allowTextSelection) {
-                    e.preventDefault();
-                }
-            }
-        },
-
-        addMouseHandlers: () => {
-            // unlike touch events, mousemove/up is not conveniently fired on the same element,
-            // but I don't need to listen to unrelated events all the time
-            if (!this.mouseHandlersAttached) {
-                this.mouseHandlersAttached = true;
-                document.documentElement.addEventListener('mouseleave', this.onMouseLeave, false);
-                window.addEventListener('mousemove', this.onMouseMove, true);
-                window.addEventListener('mouseup', this.onMouseUp, true);
-                window.addEventListener('blur', this.cancel, false);
-            }
-        },
-
-        removeMouseHandlers: () => {
-            if (this.mouseHandlersAttached) {
-                this.mouseHandlersAttached = false;
-                document.documentElement.removeEventListener('mouseleave', this.onMouseLeave, false);
-                window.removeEventListener('mousemove', this.onMouseMove, true);
-                window.removeEventListener('mouseup', this.onMouseUp, true);
-                window.removeEventListener('blur', this.cancel, false);
-            }
-        },
-
-        onMouseLeave: (e: MouseEvent) => {
-            e.stopPropagation();
-            if (this.usingTouch) return;
-
-            if (e.target === document.documentElement || e.relatedTarget === document.documentElement) {
-                if (this.state.onLeave) {
-                    this.state.onLeave.call(this);
-                }
-            }
-        },
-
-        onMouseDown: (e: MouseEvent & MSGesture) => {
-            e.stopPropagation();
-            if (this.usingTouch || e.button != 0 || !this.setTarget(e)) return;
-
-            this.addMouseHandlers(); // mouseup, etc.
-
-            this.canPreventScrolling = true; // or rather it doesn't apply to mouse
-
-            this.startAtPosition({
-                x: e.clientX,
-                y: e.clientY,
-                time: e.timeStamp,
+    getSiblings(target: ITarget): ISibling[] {
+        const siblings = [];
+        let tmp = target.node.nextSibling;
+        while (tmp) {
+            if (tmp.nodeType == 1) siblings.push({
+                node: tmp as HTMLElement,
+                baseTransform: getTransform(tmp as HTMLElement),
             });
-        },
+            tmp = tmp.nextSibling;
+        }
+        return siblings;
+    }
 
-        onTouchStart: (e: TouchEvent) => {
-            e.stopPropagation();
-            this.usingTouch = true;
-            this.canPreventScrolling = true;
+    animateToZero(callback: (target: ITarget) => void, target: ITarget) {
+        // save, because this.target/container could change during animation
+        target = target || this.target;
 
-            // This implementation cares only about single touch
-            if (e.touches.length > 1) {
-                this.setState(this.states.idle);
-                return;
-            }
+        target.node.style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.1s ease-out';
+        target.node.style[transformJSPropertyName] = 'translate(0,0) ' + hwLayerMagicStyle + target.baseTransform.value;
+        setTimeout(() => {
+                target.node.style[transitionJSPropertyName] = '';
+                target.node.style[transformJSPropertyName] = target.baseTransform.original;
+                if (callback) callback.call(this, target);
+            }, 101
+        );
+    }
 
-            if (e.target != null && !this.setTarget(e)) return;
+    /// states
 
-            this.startAtPosition({
-                x: e.touches[0].clientX,
-                y: e.touches[0].clientY,
-                time: e.timeStamp,
-            });
-        },
+    animateSwipe(callback: (target: ITarget) => void): void | boolean {
+        const target: ITarget = this.target;
+        const siblings = this.getSiblings(target);
+        const emptySpaceTransformStyle = 'translate(0,' + this.target.height + 'px) ' + hwLayerMagicStyle + ' ';
 
-        setTarget: (e: Event & {target?: Node | null}): boolean => {
-            const targetNode = this.findTargetNode(e.target);
-            if (!targetNode) {
-                this.setState(this.states.idle);
-                return false;
-            }
+        // FIXME: animate with real velocity
+        target.node.style[transitionJSPropertyName] = 'all 0.1s linear';
+        target.node.style[transformJSPropertyName] = ' translate(' + (this.getTotalMovement().x > 0 ? '' : '-') + '100%,0) ' + hwLayerMagicStyle + target.baseTransform.value;
 
-            //check for a scrollable parent
-            let scrollContainer = targetNode.parentNode as HTMLElement;
-            while (scrollContainer) {
-                if (scrollContainer == document.body) break;
-                if (scrollContainer.scrollHeight > scrollContainer.clientHeight && window.getComputedStyle(scrollContainer).overflowY !== 'visible') break;
-                scrollContainer = scrollContainer.parentNode as HTMLElement;
-            }
-            scrollContainer = scrollContainer || document.body;
-
-            this.target = {
-                originalTarget: e.target as any as ITarget,
-                node: targetNode as ITarget['node'],
-                scrollContainer: scrollContainer,
-                origScrollTop: scrollContainer.scrollTop,
-                origScrollHeight: scrollContainer.scrollHeight,
-                baseTransform: getTransform(targetNode as HTMLElement),
-            };
-            return true;
-        },
-
-        startAtPosition: (pos: IPosition) => {
-            this.startPosition = this.previousPosition = this.latestPosition = pos;
-            this.setState(this.states.undecided);
-        },
-
-        updatePosition: (e: MouseEvent | TouchEvent, pos: IPosition) => {
-            if (this.target == null) {
-                return;
-            }
-            this.latestPosition = pos;
-
-            if (this.state.onMove) {
-                if (this.state.onMove.call(this) === false) {
-                    e.preventDefault();
-                }
-            }
-
-            // sample latestPosition 100ms for velocity
-            if (this.latestPosition.time - this.previousPosition.time > 100) {
-                this.previousPosition = this.latestPosition;
-            }
-        },
-
-        onMouseMove: (e: MouseEvent) => {
-            e.stopPropagation();
-            this.updatePosition(e, {
-                x: e.clientX,
-                y: e.clientY,
-                time: e.timeStamp,
-            });
-        },
-
-        onTouchMove: (e: TouchEvent) => {
-            e.stopPropagation();
-            this.updatePosition(e, {
-                x: e.touches[0].clientX,
-                y: e.touches[0].clientY,
-                time: e.timeStamp,
-            });
-
-            // In Apple's touch model only the first move event after touchstart can prevent scrolling (and event.cancelable is broken)
-            this.canPreventScrolling = false;
-        },
-
-        onMouseUp: (e: MouseEvent) => {
-            e.stopPropagation();
-            if (this.usingTouch || e.button !== 0) return;
-
-            if (this.state.onEnd && false === this.state.onEnd.call(this)) {
-                e.preventDefault();
-            }
-        },
-
-        onTouchEnd: (e: TouchEvent) => {
-            e.stopPropagation();
-            if (e.touches.length > 1) {
-                this.cancel();
-            } else if (this.state.onEnd && false === this.state.onEnd.call(this)) {
-                e.preventDefault();
-            }
-        },
-
-        getTotalMovement: (): ISlip['latestPosition'] => {
-            const scrollOffset = this.target.scrollContainer.scrollTop - this.target.origScrollTop;
-            return {
-                x: this.latestPosition.x - this.startPosition.x,
-                y: this.latestPosition.y - this.startPosition.y + scrollOffset,
-                time: this.latestPosition.time - this.startPosition.time,
-            };
-        },
-
-        getAbsoluteMovement: () => {
-            const move = this.getTotalMovement();
-            return {
-                x: Math.abs(move.x),
-                y: Math.abs(move.y),
-                time: move.time,
-                directionX: move.x < 0 ? 'left' : 'right',
-                directionY: move.y < 0 ? 'up' : 'down',
-            };
-        },
-
-        updateScrolling: () => {
-            const triggerOffset = 40;
-            let offset = 0;
-
-            const scrollable = this.target.scrollContainer,
-                containerRect = scrollable.getBoundingClientRect(),
-                targetRect = this.target.node.getBoundingClientRect(),
-                bottomOffset = Math.min(containerRect.bottom, window.innerHeight) - targetRect.bottom,
-                topOffset = targetRect.top - Math.max(containerRect.top, 0),
-                maxScrollTop = this.target.origScrollHeight - Math.min(scrollable.clientHeight, window.innerHeight);
-
-            if (bottomOffset < triggerOffset) {
-                offset = Math.min(triggerOffset, triggerOffset - bottomOffset);
-            }
-            else if (topOffset < triggerOffset) {
-                offset = Math.max(-triggerOffset, topOffset - triggerOffset);
-            }
-
-            scrollable.scrollTop = Math.max(0, Math.min(maxScrollTop, scrollable.scrollTop + offset));
-        },
-
-        dispatch: (targetNode: EventTarget, eventName: string, detail: any) => {
-            let event = document.createEvent('CustomEvent');
-            if (event && event.initCustomEvent) {
-                event.initCustomEvent('slip:' + eventName, true, true, detail);
-            } else {
-                event = document.createEvent('Event') as CustomEvent<any>;
-                event.initEvent('slip:' + eventName, true, true);
-                // event.detail = detail;
-            }
-            return targetNode.dispatchEvent(event);
-        },
-
-        getSiblings: (target: ITarget): ISibling[] => {
-            const siblings = [];
-            let tmp = target.node.nextSibling;
-            while (tmp) {
-                if (tmp.nodeType == 1) siblings.push({
-                    node: tmp as HTMLElement,
-                    baseTransform: getTransform(tmp as HTMLElement),
-                });
-                tmp = tmp.nextSibling;
-            }
-            return siblings;
-        },
-
-        animateToZero: (callback: (target: ITarget) => void, target: ITarget) => {
-            // save, because this.target/container could change during animation
-            target = target || this.target;
-
-            target.node.style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.1s ease-out';
-            target.node.style[transformJSPropertyName] = 'translate(0,0) ' + hwLayerMagicStyle + target.baseTransform.value;
-            setTimeout(() => {
-                    target.node.style[transitionJSPropertyName] = '';
-                    target.node.style[transformJSPropertyName] = target.baseTransform.original;
-                    if (callback) callback.call(this, target);
-                }, 101
-            );
-        },
-
-        animateSwipe: (callback: (target: ITarget) => void): void | boolean => {
-            const target: ITarget = this.target;
-            const siblings = this.getSiblings(target);
-            const emptySpaceTransformStyle = 'translate(0,' + this.target.height + 'px) ' + hwLayerMagicStyle + ' ';
-
-            // FIXME: animate with real velocity
-            target.node.style[transitionJSPropertyName] = 'all 0.1s linear';
-            target.node.style[transformJSPropertyName] = ' translate(' + (this.getTotalMovement().x > 0 ? '' : '-') + '100%,0) ' + hwLayerMagicStyle + target.baseTransform.value;
-
-            setTimeout(() => {
-                    if (callback.call(this, target)) {
+        setTimeout(() => {
+                if (callback.call(this, target)) {
+                    siblings.forEach((o: ISibling) => {
+                        o.node.style[transitionJSPropertyName] = '';
+                        o.node.style[transformJSPropertyName] = emptySpaceTransformStyle + o.baseTransform.value;
+                    });
+                    setTimeout(() => {
                         siblings.forEach((o: ISibling) => {
-                            o.node.style[transitionJSPropertyName] = '';
-                            o.node.style[transformJSPropertyName] = emptySpaceTransformStyle + o.baseTransform.value;
+                            o.node.style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.1s ease-in-out';
+                            o.node.style[transformJSPropertyName] = 'translate(0,0) ' + hwLayerMagicStyle + o.baseTransform.value;
                         });
                         setTimeout(() => {
                             siblings.forEach((o: ISibling) => {
-                                o.node.style[transitionJSPropertyName] = transformCSSPropertyName + ' 0.1s ease-in-out';
-                                o.node.style[transformJSPropertyName] = 'translate(0,0) ' + hwLayerMagicStyle + o.baseTransform.value;
+                                o.node.style[transitionJSPropertyName] = '';
+                                o.node.style[transformJSPropertyName] = o.baseTransform.original;
                             });
-                            setTimeout(() => {
-                                siblings.forEach((o: ISibling) => {
-                                    o.node.style[transitionJSPropertyName] = '';
-                                    o.node.style[transformJSPropertyName] = o.baseTransform.original;
-                                });
-                            }, 101);
-                        }, 1);
-                    }
-                }, 101
-            );
-        },
-    };
-    return Slip as any;
-};
+                        }, 101);
+                    }, 1);
+                }
+            }, 101
+        );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "strict": true,                           /* Enable all strict type-checking options. */
-    "types": ["slip.d.ts"],                 /* Type declaration files to be included in compilation. */
+    // "types": ["./slip.d.ts"],              /* Type declaration files to be included in compilation. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "types": ["slip.d.ts"],                 /* Type declaration files to be included in compilation. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  }
+}


### PR DESCRIPTION
Nothing too crazy (like a `function`→`class` conversion). Just annotated with types, replaced `var` with `let`/`const`, moved to arrow functions, and switched to the new ES6 `export` syntax.

BTW: With arrow functions I think we can remove all the `bind`s also.