### PR TITLE
change aria-role to role

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -115,12 +115,13 @@ window['Slip'] = (function(){
     var accessibility = {
         // Set values to false if you don't want Slip to manage them
         container: {
-            ariaRole: "listbox",
+            role: "listbox",
             tabIndex: 0,
             focus: false, // focuses after drop
         },
         items: {
-            ariaRole: "option", // If "option" flattens items, try "group": https://www.marcozehe.de/2013/03/08/sometimes-you-have-to-use-illegal-wai-aria-to-make-stuff-work/
+            role: "option", // If "option" flattens items, try "group":
+            // https://www.marcozehe.de/2013/03/08/sometimes-you-have-to-use-illegal-wai-aria-to-make-stuff-work/
             tabIndex: -1, // 0 will make every item tabbable, which isn't always useful
             focus: false, // focuses when dragging
         },
@@ -540,8 +541,8 @@ window['Slip'] = (function(){
             if (false !== accessibility.container.tabIndex) {
                 this.container.tabIndex = accessibility.container.tabIndex;
             }
-            if (accessibility.container.ariaRole) {
-                this.container.setAttribute('aria-role', accessibility.container.ariaRole);
+            if (accessibility.container.role) {
+                this.container.setAttribute('role', accessibility.container.role);
             }
             this.setChildNodesAriaRoles();
             this.container.addEventListener('focus', this.onContainerFocus, false);
@@ -574,8 +575,8 @@ window['Slip'] = (function(){
             if (false !== accessibility.container.tabIndex) {
                 this.container.removeAttribute('tabIndex');
             }
-            if (accessibility.container.ariaRole) {
-                this.container.removeAttribute('aria-role');
+            if (accessibility.container.role) {
+                this.container.removeAttribute('role');
             }
             this.unSetChildNodesAriaRoles();
 
@@ -617,8 +618,8 @@ window['Slip'] = (function(){
             var nodes = this.container.childNodes;
             for(var i=0; i < nodes.length; i++) {
                 if (nodes[i].nodeType != 1) continue;
-                if (accessibility.items.ariaRole) {
-                    nodes[i].setAttribute('aria-role', accessibility.items.ariaRole);
+                if (accessibility.items.role) {
+                    nodes[i].setAttribute('role', accessibility.items.role);
                 }
                 if (false !== accessibility.items.tabIndex) {
                     nodes[i].tabIndex = accessibility.items.tabIndex;
@@ -630,8 +631,8 @@ window['Slip'] = (function(){
             var nodes = this.container.childNodes;
             for(var i=0; i < nodes.length; i++) {
                 if (nodes[i].nodeType != 1) continue;
-                if (accessibility.items.ariaRole) {
-                    nodes[i].removeAttribute('aria-role');
+                if (accessibility.items.role) {
+                    nodes[i].removeAttribute('role');
                 }
                 if (false !== accessibility.items.tabIndex) {
                     nodes[i].removeAttribute('tabIndex');


### PR DESCRIPTION
Since the "role" attribute exists, there is no need for "aria-role" anymore. You should use "role" to comply to the w3.org standards for accessibility.

From [MDN's article on ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA):

```
<div id="percent-loaded" role="progressbar" aria-valuenow="75"
     aria-valuemin="0" aria-valuemax="100">
</div>
```

"Unfortunately, there isn't a more semantic tag available to developers in HTML 4, so we need to include ARIA roles and properties. These are specified by adding attributes to the element. In this example, the role="progressbar" attribute informs the browser that this element is actually a JavaScript-powered progress bar widget."

```
// Find the progress bar <div> in the DOM.
var progressBar = document.getElementById("percent-loaded");

// Set its ARIA roles and states,
// so that assistive technologies know what kind of widget it is.
progressBar.setAttribute("role", "progressbar");
progressBar.setAttribute("aria-valuemin", 0);
progressBar.setAttribute("aria-valuemax", 100);
```

For further info see:

https://www.w3.org/TR/role-attribute/
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#Roles