### PR TITLE
Fix scrolling, to use document.scrollingElement instead of document.body

### DIFF
--- a/slip.js
+++ b/slip.js
@@ -729,14 +729,19 @@ window['Slip'] = (function(){
                 return false;
             }
 
-            //check for a scrollable parent
-            var scrollContainer = targetNode.parentNode;
-            while (scrollContainer) {
-                if (scrollContainer == document.body) break;
-                if (scrollContainer.scrollHeight > scrollContainer.clientHeight && window.getComputedStyle(scrollContainer)['overflow-y'] != 'visible') break;
-                scrollContainer = scrollContainer.parentNode;
+            // scrollContainer may be explicitly set via options, otherwise search upwards for a parent with an overflow-y property
+            // fallback to document.scrollingElement (or documentElement on IE), and do not use document.body
+            var scrollContainer = this.options.scrollContainer;
+            if (!scrollContainer) {
+                var top = document.scrollingElement || document.documentElement;
+                scrollContainer = targetNode.parentNode;
+                while (scrollContainer) {
+                    if (scrollContainer == top) break;
+                    if (scrollContainer != document.body && scrollContainer.scrollHeight > scrollContainer.clientHeight && window.getComputedStyle(scrollContainer)['overflow-y'] != 'visible') break;
+                    scrollContainer = scrollContainer.parentNode;
+                }
+                scrollContainer = scrollContainer || top;
             }
-            scrollContainer = scrollContainer || document.body;
 
             this.target = {
                 originalTarget: e.target,


### PR DESCRIPTION
This fixes #109 

I refactored the logic around this some time ago, but left the choice to default to document.body.
Scrolling with document.body is no longer working in the latest versions of webkit, and we probably should have been defaulting to use document.scrollingElement all along.

IE doesn't have document.scrollingElement, but documentElement seems to work just fine.

While setting `overflow-y` on one of the parent nodes will still work with this (see `example.html` for some nested lists), I've noticed that recent versions of webkit have some strange behavior that doesn't let the scroll go all the way, when scrolling within an element, and not the entire page.  I was running into that in my app, and this fix along with some changes to the overflow-y property in my app CSS fixed the issue.

This PR also allows `scrollContainer` to be explicitly set as an option, in case anyone wants even finer control of which parent is getting its `scrollTop` set during the reorder dragging.
